### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
                     <groupId>org.eclipse.swt</groupId>
                     <artifactId>org.eclipse.swt.win32.win32.x86</artifactId>
                     <version>${swt-win32.version}</version>
-                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
It is required to remove scope runtime in (former) line 143 of pom.xml for compiling WebView under Windows XP sucessfully. Otherwise maven does not download required swt libs during compilation so that Java cannot compile the application.
